### PR TITLE
Fix GraphViz, silence retroactive conformance warnings.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -12,11 +12,11 @@
       },
       {
         "package": "GraphViz",
-        "repositoryURL": "https://github.com/SwiftDocOrg/GraphViz.git",
+        "repositoryURL": "https://github.com/wabiverse/GraphViz.git",
         "state": {
           "branch": null,
-          "revision": "70bebcf4597b9ce33e19816d6bbd4ba9b7bdf038",
-          "version": "0.2.0"
+          "revision": "88a69428f5e9aa926621851ea526ee5e03672046",
+          "version": "0.5.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/wabiverse/GraphViz.git",
         "state": {
           "branch": null,
-          "revision": "88a69428f5e9aa926621851ea526ee5e03672046",
-          "version": "0.5.0"
+          "revision": "5e597d2f580f543cf7185f260c69b6b482a68d0f",
+          "version": "0.6.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 
 let package = Package(
     name: "XcodeGen",
-    platforms: [.macOS(.v10_13)],
+    platforms: [.macOS(.v10_15)],
     products: [
         .executable(name: "xcodegen", targets: ["XcodeGen"]),
         .library(name: "XcodeGenKit", targets: ["XcodeGenKit"]),
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/stackotter/SwiftXcodeProj.git", from: "8.10.1"),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
-        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", .exact("0.2.0")),
+        .package(url: "https://github.com/wabiverse/GraphViz.git", from: "0.5.0"),
     ],
 
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/stackotter/SwiftXcodeProj.git", from: "8.10.1"),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
-        .package(url: "https://github.com/wabiverse/GraphViz.git", from: "0.5.0"),
+        .package(url: "https://github.com/wabiverse/GraphViz.git", from: "0.6.0"),
     ],
 
     targets: [

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -848,7 +848,7 @@ extension Scheme.Build: JSONEncodable {
     }
 }
 
-extension BuildType: JSONPrimitiveConvertible {
+extension BuildType: JSONUtilities.JSONPrimitiveConvertible {
 
     public typealias JSONType = String
 
@@ -880,7 +880,7 @@ extension BuildType: JSONEncodable {
     }
 }
 
-extension XCScheme.EnvironmentVariable: JSONObjectConvertible {
+extension XCScheme.EnvironmentVariable: JSONUtilities.JSONObjectConvertible {
     public static let enabledDefault = true
 
     private static func parseValue(_ value: Any) -> String {

--- a/Sources/ProjectSpec/SwiftPackage.swift
+++ b/Sources/ProjectSpec/SwiftPackage.swift
@@ -101,7 +101,7 @@ extension SwiftPackage: JSONEncodable {
     }
 }
 
-extension SwiftPackage.VersionRequirement: JSONObjectConvertible {
+extension SwiftPackage.VersionRequirement: JSONUtilities.JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         if jsonDictionary["exactVersion"] != nil {

--- a/Sources/ProjectSpec/VersionExtensions.swift
+++ b/Sources/ProjectSpec/VersionExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Version
 
-extension Version: ExpressibleByStringLiteral {
+extension Version: Swift.ExpressibleByStringLiteral {
 
     public static func parse(_ string: String) throws -> Version {
         if let version = Version(tolerant: string) {

--- a/Sources/XcodeGenCLI/Arguments.swift
+++ b/Sources/XcodeGenCLI/Arguments.swift
@@ -2,7 +2,7 @@ import Foundation
 import PathKit
 import SwiftCLI
 
-extension Path: ConvertibleFromString {
+extension Path: SwiftCLI.ConvertibleFromString {
 
     public init?(input: String) {
         self.init(input)

--- a/Sources/XcodeGenKit/CarthageVersionLoader.swift
+++ b/Sources/XcodeGenKit/CarthageVersionLoader.swift
@@ -73,7 +73,7 @@ struct CarthageVersionFile: Decodable {
     }
 }
 
-extension Platform: CodingKey {
+extension Platform: Swift.CodingKey {
 
     public var stringValue: String {
         carthageName

--- a/Sources/XcodeGenKit/GraphVizGenerator.swift
+++ b/Sources/XcodeGenKit/GraphVizGenerator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import GraphViz
 import ProjectSpec
+import DOT
 
 extension Dependency {
     var graphVizName: String {

--- a/Sources/XcodeGenKit/GraphVizGenerator.swift
+++ b/Sources/XcodeGenKit/GraphVizGenerator.swift
@@ -1,4 +1,3 @@
-import DOT
 import Foundation
 import GraphViz
 import ProjectSpec
@@ -14,7 +13,7 @@ extension Dependency {
     }
 }
 
-extension Dependency.DependencyType: CustomStringConvertible {
+extension Dependency.DependencyType: Swift.CustomStringConvertible {
     public var description: String {
         switch self {
         case .bundle: return "bundle"


### PR DESCRIPTION
This package could no longer be built on more recent **Swift 5.10+** toolchains, here are the required changes to get things working again, and allow **SwiftBundler** to be built on **macOS 10.15+** again, to include **macOS Sequoia (v15.0)**.

### **Description of Changes**

- Require a minimum **macOS** version of **10.15**.
- Fix **GraphViz** by using the latest release of [**Wabi's** fork of the **GraphViz** project](https://github.com/wabiverse/GraphViz/releases/tag/v0.5.0).
- Silence warnings for retroactive conformances by fully-qualifying all offending types in each of their extensions.